### PR TITLE
Create Set & Get API

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,9 @@ on:
   push:
     branches-ignore:
       - main
-
+  pull_request:
+    branches:
+      - main
 jobs:
   test:
     name: Test

--- a/pkg/get/get.go
+++ b/pkg/get/get.go
@@ -1,0 +1,16 @@
+package get
+
+import (
+	"errors"
+)
+
+var ErrKeyNotFound = errors.New("key not found")
+
+func Get(cache map[string]string, key string) (string, error) {
+	value, ok := cache[key]
+	if !ok {
+		return "", ErrKeyNotFound
+	}
+
+	return value, nil
+}

--- a/pkg/get/get_test.go
+++ b/pkg/get/get_test.go
@@ -1,0 +1,57 @@
+package get
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testInput struct {
+	cache map[string]string
+	key   string
+}
+
+func TestGet(t *testing.T) {
+	testCases := map[string]struct {
+		input       testInput
+		expect      string
+		expectedErr bool
+		err         error
+	}{
+		"key not found returns error": {
+			input: testInput{
+				cache: make(map[string]string),
+				key:   "testNotFoundKey",
+			},
+			expect:      "",
+			expectedErr: true,
+			err:         ErrKeyNotFound,
+		},
+		"key found ": {
+			input: testInput{
+				cache: map[string]string{
+					"testKey": "testValue",
+				},
+				key: "testKey",
+			},
+			expect:      "testValue",
+			expectedErr: false,
+			err:         nil,
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			value, err := Get(tc.input.cache, tc.input.key)
+
+			if tc.expectedErr {
+				assert.Error(t, err)
+				assert.Equal(t, tc.err, err)
+				return
+			}
+
+			assert.NoError(t, err)
+			assert.Equal(t, tc.expect, value)
+		})
+	}
+}

--- a/pkg/service/cache-api/get.go
+++ b/pkg/service/cache-api/get.go
@@ -3,10 +3,32 @@ package service
 import (
 	"context"
 
+	getcmd "github.com/bgajjala8/go-cache/pkg/get"
 	pb "github.com/bgajjala8/go-cache/proto-public/go"
+	validation "github.com/go-ozzo/ozzo-validation"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-// TODO: Implement the Get method of the Service
-func (s *Service) Get(context.Context, *pb.GetRequest) (*pb.GetResponse, error) {
-	return nil, nil
+func validateGetRequest(req *pb.GetRequest) error {
+	return validation.ValidateStruct(req, validation.Field(&req.Key, validation.Required))
+}
+
+func (s *Service) Get(ctx context.Context, req *pb.GetRequest) (*pb.GetResponse, error) {
+	err := validateGetRequest(req)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "validation error: %s", err.Error())
+	}
+
+	resp, err := getcmd.Get(s.cache, req.GetKey())
+	if err != nil {
+		switch err {
+		case getcmd.ErrKeyNotFound:
+			return nil, status.Errorf(codes.NotFound, "key not found: %s", req.GetKey())
+		default:
+			return nil, status.Errorf(codes.Internal, "error getting key: %s", err.Error())
+		}
+	}
+
+	return &pb.GetResponse{Key: req.GetKey(), Value: resp}, nil
 }

--- a/pkg/service/cache-api/set.go
+++ b/pkg/service/cache-api/set.go
@@ -3,10 +3,27 @@ package service
 import (
 	"context"
 
+	setcmd "github.com/bgajjala8/go-cache/pkg/set"
 	pb "github.com/bgajjala8/go-cache/proto-public/go"
+	validation "github.com/go-ozzo/ozzo-validation"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-// TODO: Implement the Set method of the Service
-func (s *Service) Set(context.Context, *pb.SetRequest) (*pb.SetResponse, error) {
-	return nil, nil
+func validateSetRequest(req *pb.SetRequest) error {
+	return validation.ValidateStruct(req,
+		validation.Field(&req.Key, validation.Required),
+		validation.Field(&req.Value, validation.Required),
+	)
+}
+
+func (s *Service) Set(ctx context.Context, req *pb.SetRequest) (*pb.SetResponse, error) {
+	err := validateSetRequest(req)
+	if err != nil {
+		return nil, status.Errorf(codes.InvalidArgument, "validation error: %s", err.Error())
+	}
+
+	resp := setcmd.Set(s.cache, req.GetKey(), req.GetValue())
+
+	return &pb.SetResponse{Key: req.GetKey(), Value: resp}, nil
 }

--- a/pkg/set/set.go
+++ b/pkg/set/set.go
@@ -1,0 +1,7 @@
+package set
+
+func Set(cache map[string]string, key, value string) string {
+	cache[key] = value
+
+	return cache[key]
+}

--- a/pkg/set/set_test.go
+++ b/pkg/set/set_test.go
@@ -1,0 +1,47 @@
+package set
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testInput struct {
+	cache map[string]string
+	key   string
+	value string
+}
+
+func TestSet(t *testing.T) {
+	testCases := map[string]struct {
+		input  testInput
+		expect string
+	}{
+		"set key": {
+			input: testInput{
+				cache: make(map[string]string),
+				key:   "testKey",
+				value: "testValue",
+			},
+			expect: "testValue",
+		},
+		"update key": {
+			input: testInput{
+				cache: map[string]string{
+					"testKey": "testValue",
+				},
+				key:   "testKey",
+				value: "updatedValue",
+			},
+			expect: "updatedValue",
+		},
+	}
+
+	for name, tc := range testCases {
+		t.Run(name, func(t *testing.T) {
+			value := Set(tc.input.cache, tc.input.key, tc.input.value)
+
+			assert.Equal(t, tc.expect, value)
+		})
+	}
+}


### PR DESCRIPTION
## Overview

<!-- Provide a brief overview and or bullet point of changes made -->
- Create `pkg` for `set` and `get`
   - Includes unit testing'
- Create `gRPC` service endpoints to handle requests and validations. 
## Testing
<!-- Enumerate details if any for testing that was done before publishing PR -->
- Tested via `grpcui` to call locally the endpoint as follows 
   1. `set` key with value x, returned ok
   2. `get` key, returned value x
   3. `set` key with new value y, returned ok 
   4. `get` key, returned value y
   5. `delete` key, returned ok 
   6. `get` key, returned not found
## Checklist 
- [ ] If applicable, I've documented a plan to revert these changes if it requires more than reverting the PR. 

## Notes
<!-- Any additional details to provide regarding the PR -->
- We should start adding unit tests for our `service` endpoints. 